### PR TITLE
Fixed Google Indexing

### DIFF
--- a/website/_includes/_head.html
+++ b/website/_includes/_head.html
@@ -9,10 +9,6 @@
 
     <title>{{ page_title }}</title>
 
-    {% if page.hide_from_search or jekyll.environment !='production' %}
-    <meta name="robots" content="noindex, nofollow" />
-    {% endif %}
-
     <meta name="description" content="{{ page_description }}" />
     <link rel="canonical" href="{{ url_path }}" />
 


### PR DESCRIPTION
This meta tag is incorrectly blocking Google indexing, due to a change in the jekyll environment names.

This change will eventually flow through the lower environments.  This change fixes prod directly, because clearance could take a while.